### PR TITLE
Fix cannot to disable spring counter

### DIFF
--- a/GrailsMelodyGrailsPlugin.groovy
+++ b/GrailsMelodyGrailsPlugin.groovy
@@ -126,7 +126,7 @@ class GrailsMelodyGrailsPlugin {
 		def SPRING_COUNTER = MonitoringProxy.getSpringCounter()
 		final boolean DISABLED = GrailsMelodyUtil.getGrailsMelodyConfig(application)?.javamelody?.disabled || Boolean.parseBoolean(Parameters.getParameter(Parameter.DISABLED))
 
-		if (DISABLED || !SPRING_COUNTER.isDisplayed()) {
+		if (DISABLED || !SPRING_COUNTER.isUsed()) {
 			return
 		}
 

--- a/GrailsMelodyGrailsPlugin.groovy
+++ b/GrailsMelodyGrailsPlugin.groovy
@@ -126,7 +126,7 @@ class GrailsMelodyGrailsPlugin {
 		def SPRING_COUNTER = MonitoringProxy.getSpringCounter()
 		final boolean DISABLED = GrailsMelodyUtil.getGrailsMelodyConfig(application)?.javamelody?.disabled || Boolean.parseBoolean(Parameters.getParameter(Parameter.DISABLED))
 
-		if (DISABLED || !SPRING_COUNTER.isUsed()) {
+		if (DISABLED || Parameters.isCounterHidden(SPRING_COUNTER.getName())) {
 			return
 		}
 


### PR DESCRIPTION
Service interceptor from plugin is a bit buggy. So I want to disable it. But I can't.

This is because counter's `displayed` property is will be set later when `MonitoringFilter` will be initialized. 

It seems to be better to use `isUsed` method which check counter availability in context `init-params`.