### PR TITLE
fix interception when method is a closure

### DIFF
--- a/GrailsMelodyGrailsPlugin.groovy
+++ b/GrailsMelodyGrailsPlugin.groovy
@@ -163,7 +163,14 @@ class GrailsMelodyGrailsPlugin {
 						def property = delegate."${name}"
 						if(property instanceof Closure){
 							found = true
-							metaMethod = [doMethodInvoke: {dlg, arguments-> property.call(arguments)}]
+							metaMethod = [doMethodInvoke: { dlg, arguments -> 
+								def theArgs = arguments
+									? arguments.size() == 1
+										? arguments[0]
+										: arguments as List
+									: null
+								property.call(theArgs)
+							}]
 						}
 					}
 					if (!found){


### PR DESCRIPTION
When the method of a service is a closure the `args` must be transformed for proper handling of the closure.

The problem can be reproduced as follows:

```groovy
class X { def myClosure = { "${it?.class?.simpleName}:$it" } }
class Y { def myClosure = { "${it?.class?.simpleName}:$it" } }

X.metaClass.invokeMethod = { String name, args ->
    property = delegate."${name}"
    // actual implementation
    property.call(args)
    // solution
//    property.call(args ? args.size() == 1 ? args[0] : args as List : null)
}

assert new X().myClosure('a') == new Y().myClosure('a')
```

