### PR TITLE
Put back the previous way of proxying the dataSources 

### DIFF
--- a/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
+++ b/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
@@ -1,9 +1,11 @@
 package grails.melody.plugin
 
 import grails.plugins.Plugin
-import net.bull.javamelody.SpringDataSourceBeanPostProcessor
+import net.bull.javamelody.JdbcWrapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+
+import javax.sql.DataSource
 
 class GrailsMelodyPluginGrailsPlugin extends Plugin {
 
@@ -38,12 +40,20 @@ class GrailsMelodyPluginGrailsPlugin extends Plugin {
         new MelodyInterceptorEnhancer().enhance(getGrailsApplication())
     }
 
+    void doWithApplicationContext() {
+        //Need to wrap the datasources here, because BeanPostProcessor didn't worked.
+        def beans = getApplicationContext().getBeansOfType(DataSource)
+        beans.each { beanName, bean ->
+            if (beanName.contains('Lazy')) {
+                LOG.debug "Wrapping DataSource - $beanName"
+                bean.targetDataSource = JdbcWrapper.SINGLETON.createDataSourceProxy(bean.targetDataSource)
+            }
+        }
+    }
+
     Closure doWithSpring() {
         { ->
             melodyConfig(MelodyConfig)
-
-            //Wrap grails datasource with java melody JdbcWapper
-            springDataSourceBeanPostProcessor(SpringDataSourceBeanPostProcessor)
         }
     }
 }


### PR DESCRIPTION
Since the SpringPortProcessor is not working anymore.

We only proxy the '...Lazy' beans.