### PR TITLE
Add back enabling expando globally

### DIFF
--- a/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
+++ b/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
@@ -70,6 +70,7 @@ class GrailsMelodyPluginGrailsPlugin extends Plugin {
 
     Closure doWithSpring() {
         { ->
+            ExpandoMetaClass.enableGlobally()
             melodyConfig(MelodyConfig)
         }
     }

--- a/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
+++ b/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
@@ -9,6 +9,10 @@ import javax.sql.DataSource
 
 class GrailsMelodyPluginGrailsPlugin extends Plugin {
 
+    static {
+        ExpandoMetaClass.enableGlobally()
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(GrailsMelodyPluginGrailsPlugin.class)
 
     // the version or versions of Grails the plugin is designed for
@@ -70,7 +74,6 @@ class GrailsMelodyPluginGrailsPlugin extends Plugin {
 
     Closure doWithSpring() {
         { ->
-            ExpandoMetaClass.enableGlobally()
             melodyConfig(MelodyConfig)
         }
     }


### PR DESCRIPTION
to properly support subclassing of services and other stuff. This makes intercepting all service calls work as they were a while ago. The code is done in the doWithSpring phase to avoid removing metaclass changes done by Grails (see #43)

Fixes #63 