### PR TITLE
Only enable metaclass when not in test

### DIFF
--- a/plugin/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/grails/melody/plugin/GrailsMelodyPluginGrailsPlugin.groovy
@@ -12,7 +12,8 @@ class GrailsMelodyPluginGrailsPlugin extends Plugin {
 
     static {
         //Plugin needs ExpandoMetaClass to be able to monitor Grails Services correctly.
-        ExpandoMetaClass.enableGlobally()
+        if (Environment.current != Environment.TEST)
+            ExpandoMetaClass.enableGlobally()
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(GrailsMelodyPluginGrailsPlugin.class)


### PR DESCRIPTION
It breaks some annotations used in Spock (ie @ConfineMetaClassChanges).